### PR TITLE
Bugfix for missing setup call and deprecation fixes

### DIFF
--- a/esphome/components/somfy_cover/cover.py
+++ b/esphome/components/somfy_cover/cover.py
@@ -25,7 +25,8 @@ CONF_REMOTE_CODE = "remote_code"
 CONF_SOMFY_STORAGE_KEY = "storage_key"
 
 CONFIG_SCHEMA = cv.All(
-    cover.COVER_SCHEMA.extend(
+    cover.cover_schema(SomfyCover)
+    .extend(
         {
             cv.GenerateID(): cv.declare_id(SomfyCover),
             cv.Required(CONF_PROG_BUTTON): cv.use_id(button.Button),

--- a/esphome/components/somfy_cover/somfy_cover.cpp
+++ b/esphome/components/somfy_cover/somfy_cover.cpp
@@ -15,22 +15,23 @@ void SomfyCover::setup() {
 
   // Setup the Somfy Remote
   this->remote_ = new SomfyRemote(this->cc1101_module_->get_emitter_pin(), this->remote_code_, this->storage_);
+  this->remote_->setup();
 
   // Attach to timebased cover controls
   automationTriggerUp_ = new Automation<>(this->get_open_trigger());
-  actionTriggerUp = new SomfyCoverAction<>([=] { return this->open(); });
+  actionTriggerUp = new SomfyCoverAction<>([=, this] { return this->open(); });
   automationTriggerUp_->add_action(actionTriggerUp);
 
   automationTriggerDown_ = new Automation<>(this->get_close_trigger());
-  actionTriggerDown_ = new SomfyCoverAction<>([=] { return this->close(); });
+  actionTriggerDown_ = new SomfyCoverAction<>([=, this] { return this->close(); });
   automationTriggerDown_->add_action(actionTriggerDown_);
 
   automationTriggerStop_ = new Automation<>(this->get_stop_trigger());
-  actionTriggerStop_ = new SomfyCoverAction<>([=] { return this->stop(); });
+  actionTriggerStop_ = new SomfyCoverAction<>([=, this] { return this->stop(); });
   automationTriggerStop_->add_action(actionTriggerStop_);
 
   // Attach the prog button
-  this->cover_prog_button_->add_on_press_callback([=] { return this->program(); });
+  this->cover_prog_button_->add_on_press_callback([=, this] { return this->program(); });
 
   // Set extra settings
   this->has_built_in_endstop_ = true;
@@ -77,7 +78,7 @@ void SomfyCover::program() {
 }
 
 void SomfyCover::send_command(Command command) {
-  this->cc1101_module_->sent_command([=] { this->remote_->sendCommand(command); });
+  this->cc1101_module_->sent_command([=, this] { this->remote_->sendCommand(command); });
 }
 
 }  // namespace somfy_cover


### PR DESCRIPTION
This merge request fixes a missing call to the remote setup function that sets the correct pin mode.
The following deprecations are also fixed:
- The ESPHome schema COVER_SCHEMA is replaced with the cover_schema() function
- lambda function parameter for the context ([=]) is updated to ([=, this]) for cpp20