### PR TITLE
Feature/repeat command parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cover:
     storage_key: "bathroom"
     prog_button: "program_bathroom"
     cc1101_module: "cc1101_module"
+    repeat_command_count: 1
 
 ```
 
@@ -119,7 +120,10 @@ For example, use the website: https://www.browserling.com/tools/random-hex
 Set to 6 digits and add `0x` in front of the generated hex number.
 
 ## Pair the cover
-Put your cover in program mode with another remote, then use the `Program x` button to pair with the ESP. From then on the cover should respond to the ESPHome Somfy controller.
+Put your cover in program mode with another remote, then use the `Program x` button to pair with the ESP. From then on the cover should respond to the ESPHome Somfy controller. You can also connect multiple covers by pairing then one by one with the same `Program x` button.
+
+## Repeating command setting
+The *Somfy_Remote_Lib* library defaults to sending a command four times. Some devices do not handle this well and should only reveive the command one time. For these devices the optional parameter `repeat_command_count` can be set in the yaml for the cover.
 
 ## Credits
 I originally used the ESPHome custom component from [evgeni](https://github.com/evgeni/esphome-configs/) after I found his article [Controlling Somfy roller shutters using an ESP32 and ESPHome](https://www.die-welt.net/2021/06/controlling-somfy-roller-shutters-using-an-esp32-and-esphome/).

--- a/esphome/components/somfy_cover/cover.py
+++ b/esphome/components/somfy_cover/cover.py
@@ -23,6 +23,7 @@ CONF_CC1101_MODULE = "cc1101_module"
 CONF_PROG_BUTTON = "prog_button"
 CONF_REMOTE_CODE = "remote_code"
 CONF_SOMFY_STORAGE_KEY = "storage_key"
+CONF_REPEAT_COMMAND_COUNT = "repeat_command_count"
 
 CONFIG_SCHEMA = cv.All(
     cover.cover_schema(SomfyCover)
@@ -35,6 +36,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
             cv.Required(CONF_REMOTE_CODE): cv.uint32_t,
             cv.Required(CONF_SOMFY_STORAGE_KEY): cv.All(cv.string, cv.Length(max=15)),
+            cv.Optional(CONF_REPEAT_COMMAND_COUNT, default=4): cv.int_range(min=1, max=100),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
@@ -62,3 +64,5 @@ async def to_code(config):
     cg.add(var.set_remote_code(config[CONF_REMOTE_CODE]))
 
     cg.add(var.set_storage_key(config[CONF_SOMFY_STORAGE_KEY]))
+
+    cg.add(var.set_repeat_count(config[CONF_REPEAT_COMMAND_COUNT]))

--- a/esphome/components/somfy_cover/somfy_cover.cpp
+++ b/esphome/components/somfy_cover/somfy_cover.cpp
@@ -78,7 +78,7 @@ void SomfyCover::program() {
 }
 
 void SomfyCover::send_command(Command command) {
-  this->cc1101_module_->sent_command([=, this] { this->remote_->sendCommand(command); });
+  this->cc1101_module_->sent_command([=, this] { this->remote_->sendCommand(command, this->repeat_count_); });
 }
 
 }  // namespace somfy_cover

--- a/esphome/components/somfy_cover/somfy_cover.h
+++ b/esphome/components/somfy_cover/somfy_cover.h
@@ -49,6 +49,7 @@ class SomfyCover : public time_based::TimeBasedCover {
   void set_prog_button(button::Button *cover_prog_button) { this->cover_prog_button_ = cover_prog_button; }
   void set_remote_code(uint32_t remote_code_) { this->remote_code_ = remote_code_; }
   void set_storage_key(const char *storage_key_) { this->storage_key_ = storage_key_; }
+  void set_repeat_count(int repeat_count_) { this->repeat_count_ = repeat_count_; }
 
   cover::CoverTraits get_traits() override;
 
@@ -60,6 +61,7 @@ class SomfyCover : public time_based::TimeBasedCover {
   button::Button *cover_prog_button_{nullptr};
   uint32_t remote_code_{0};
   const char *storage_key_;
+  const int repeat_count_{4};  // Number of times to repeat the command
 
   // Set via the constructor
   SomfyRemote *remote_;

--- a/esphome/components/somfy_cover/somfy_cover.h
+++ b/esphome/components/somfy_cover/somfy_cover.h
@@ -61,7 +61,7 @@ class SomfyCover : public time_based::TimeBasedCover {
   button::Button *cover_prog_button_{nullptr};
   uint32_t remote_code_{0};
   const char *storage_key_;
-  const int repeat_count_{4};  // Number of times to repeat the command
+  int repeat_count_{4};  // Number of times to repeat the command
 
   // Set via the constructor
   SomfyRemote *remote_;


### PR DESCRIPTION
Added an optional parameter to set the command repeat times when sending a command. Usefull for some devices that do not work properly with the default of 4 repeats.