### PR TITLE
Use official ESPHome CC1101 and Remote Transmitter components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # ESPHome Somfy cover remote
-This is an external component for [ESPHOME](https://esphome.io/), to control Somfy RTS covers from for example [Home Assisant](https://www.home-assistant.io/).
+This is an external component for [ESPHome](https://esphome.io/), to control Somfy RTS covers from for example [Home Assistant](https://www.home-assistant.io/).
+
+Uses the official ESPHome [CC1101](https://esphome.io/components/cc1101/) and [Remote Transmitter](https://esphome.io/components/remote_transmitter/) components for RF transmission. Works with both the Arduino and ESP-IDF frameworks.
 
 ## Required hardware
 - ESP32
 - CC1101 RF module
 
 ## Setup
-Use the following ESPHome yaml as a base for your Somfy controller. Add one ore more covers, depending on your needs.
+Use the following ESPHome yaml as a base for your Somfy controller. Add one or more covers, depending on your needs.
 
-```
+```yaml
 esphome:
   name: somfycontroller
 
 external_components:
-  - source: github://HarmEllis/esphome-cc1101@main
-    components: [ cc1101 ]
   - source: github://HarmEllis/esphome-somfy-cover-remote@main
     components: [ somfy_cover ]
 
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 # Enable logging
 logger:
@@ -37,7 +37,7 @@ wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
 
-  Enable fallback hotspot (captive portal) in case wifi connection fails
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "Somfycontroller Fallback Hotspot"
     password: !secret fallback_hotspot
@@ -56,15 +56,28 @@ button:
     id: "program_bathroom"
     name: "Program bathroom"
 
-# For the WT32-ETH01 ESP module, you can use these pins
+# SPI bus for CC1101 (adjust pins for your board)
+spi:
+  clk_pin: GPIO14
+  mosi_pin: GPIO12
+  miso_pin: GPIO39
+
+# Official ESPHome CC1101 component
 cc1101:
-  id: "cc1101_module"
-  cc1101_frequency: 433.42
-  mosi_pin: 12
-  miso_pin: 39
-  clk_pin: 14
-  cs_pin: 15
-  cc1101_emitter_pin: 2
+  cs_pin: GPIO15
+  frequency: 433.42MHz
+
+# Remote transmitter connected to CC1101 GDO0 pin
+remote_transmitter:
+  id: "transmitter"
+  pin: GPIO2
+  carrier_duty_percent: 100%
+  on_transmit:
+    then:
+      - cc1101.begin_tx
+  on_complete:
+    then:
+      - cc1101.set_idle
 
 cover:
   - platform: somfy_cover
@@ -76,8 +89,8 @@ cover:
     remote_code: 0x6b2a03
     storage_key: "livingroom"
     prog_button: "program_livingroom"
-    cc1101_module: "cc1101_module"
-  
+    remote_transmitter: "transmitter"
+
   - platform: somfy_cover
     id: "kitchen"
     name: "Kitchen cover"
@@ -87,8 +100,8 @@ cover:
     remote_code: 0x0bf93b
     storage_key: "kitchen"
     prog_button: "program_kitchen"
-    cc1101_module: "cc1101_module"
-  
+    remote_transmitter: "transmitter"
+
   - platform: somfy_cover
     id: "study"
     name: "Study cover"
@@ -98,7 +111,7 @@ cover:
     remote_code: 0x09a1c3
     storage_key: "study"
     prog_button: "program_study"
-    cc1101_module: "cc1101_module"
+    remote_transmitter: "transmitter"
 
   - platform: somfy_cover
     id: "bathroom"
@@ -109,23 +122,47 @@ cover:
     remote_code: 0x449677
     storage_key: "bathroom"
     prog_button: "program_bathroom"
-    cc1101_module: "cc1101_module"
+    remote_transmitter: "transmitter"
     repeat_command_count: 1
-
 ```
 
-## Generate remote code 
+## Configuration variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `remote_transmitter` | Yes | | ID of the `remote_transmitter` component |
+| `prog_button` | Yes | | ID of a `button` component used for pairing |
+| `open_duration` | Yes | | Time for the cover to fully open |
+| `close_duration` | Yes | | Time for the cover to fully close |
+| `remote_code` | Yes | | Unique 3-byte hex remote code (e.g. `0x6b2a03`) |
+| `storage_key` | Yes | | Key for rolling code storage in NVS (max 15 chars, unique per cover) |
+| `storage_namespace` | No | `somfy_cover` | NVS namespace for rolling code storage (max 15 chars) |
+| `repeat_command_count` | No | `4` | Number of times to repeat the RF command (1-100) |
+
+## Generate remote code
 The remote code is a three byte hex code.
-For example, use the website: https://www.browserling.com/tools/random-hex  
+For example, use the website: https://www.browserling.com/tools/random-hex
 Set to 6 digits and add `0x` in front of the generated hex number.
 
 ## Pair the cover
-Put your cover in program mode with another remote, then use the `Program x` button to pair with the ESP. From then on the cover should respond to the ESPHome Somfy controller. You can also connect multiple covers by pairing then one by one with the same `Program x` button.
+Put your cover in program mode with another remote, then use the `Program x` button to pair with the ESP. From then on the cover should respond to the ESPHome Somfy controller. You can also connect multiple covers by pairing them one by one with the same `Program x` button.
 
 ## Repeating command setting
-The *Somfy_Remote_Lib* library defaults to sending a command four times. Some devices do not handle this well and should only reveive the command one time. For these devices the optional parameter `repeat_command_count` can be set in the yaml for the cover.
+The default is to send a command four times. Some devices do not handle this well and should only receive the command one time. For these devices the optional parameter `repeat_command_count` can be set in the yaml for the cover.
+
+## Migrating from the old version
+
+If you are upgrading from the version that used `esphome-cc1101` (the custom CC1101 component), you need to make the following changes to your YAML:
+
+1. **Remove** the `esphome-cc1101` external component reference
+2. **Add** the `spi`, `cc1101` (official), and `remote_transmitter` components (see example above)
+3. **Replace** `cc1101_module` with `remote_transmitter` in each cover configuration
+
+Your rolling codes stored in NVS will be preserved automatically (the default `storage_namespace` is `somfy_cover`, matching the previous version). No re-pairing is needed.
 
 ## Credits
 I originally used the ESPHome custom component from [evgeni](https://github.com/evgeni/esphome-configs/) after I found his article [Controlling Somfy roller shutters using an ESP32 and ESPHome](https://www.die-welt.net/2021/06/controlling-somfy-roller-shutters-using-an-esp32-and-esphome/).
 
-But I wanted to be able to specify the cover position by used the ESPHome [Time Based Cover](https://esphome.io/components/cover/time_based.html) component. I used the code from evgeni as as base and used the ESPHome Custom component option to implement this. Since the Custom component option is deprecated and removed, I needed another solution. Therefore I created this external component.
+But I wanted to be able to specify the cover position by used the ESPHome [Time Based Cover](https://esphome.io/components/cover/time_based.html) component. I used the code from evgeni as a base and used the ESPHome Custom component option to implement this. Since the Custom component option is deprecated and removed, I needed another solution. Therefore I created this external component.
+
+The refactoring to use the official ESPHome CC1101 and Remote Transmitter components was inspired by the proof-of-concept from [@fawick](https://github.com/fawick/somfy_cover_2025.12).

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If you are upgrading from the version that used `esphome-cc1101` (the custom CC1
 2. **Add** the `spi`, `cc1101` (official), and `remote_transmitter` components (see example above)
 3. **Replace** `cc1101_module` with `remote_transmitter` in each cover configuration
 
-Your rolling codes stored in NVS will be preserved automatically (the default `storage_namespace` is `somfy_cover`, matching the previous version). No re-pairing is needed.
+**Note:** If you are also switching from the Arduino to the ESP-IDF framework, the NVS partition will be erased. This means your rolling codes will be lost and you will need to generate new `remote_code` values and re-pair your covers.
 
 ## Credits
 I originally used the ESPHome custom component from [evgeni](https://github.com/evgeni/esphome-configs/) after I found his article [Controlling Somfy roller shutters using an ESP32 and ESPHome](https://www.die-welt.net/2021/06/controlling-somfy-roller-shutters-using-an-esp32-and-esphome/).

--- a/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
+++ b/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
@@ -1,0 +1,54 @@
+#include "NVSRollingCodeStorage.h"
+#include "esphome/core/log.h"
+#include <nvs_flash.h>
+#include <nvs.h>
+
+namespace esphome {
+namespace somfy_cover {
+
+static const char *TAG = "somfy_cover.nvs";
+
+uint16_t NVSRollingCodeStorage::next_code() {
+  uint16_t code = 1;
+  nvs_handle_t handle;
+
+  esp_err_t err = nvs_flash_init();
+  if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    ESP_LOGW(TAG, "NVS partition truncated, erasing...");
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    err = nvs_flash_init();
+  }
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to init NVS: %s", esp_err_to_name(err));
+    return code;
+  }
+
+  err = nvs_open(this->ns_, NVS_READWRITE, &handle);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to open NVS namespace '%s': %s", this->ns_, esp_err_to_name(err));
+    return code;
+  }
+
+  err = nvs_get_u16(handle, this->key_, &code);
+  if (err == ESP_ERR_NVS_NOT_FOUND) {
+    code = 1;
+  } else if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to read rolling code: %s", esp_err_to_name(err));
+    nvs_close(handle);
+    return code;
+  }
+
+  err = nvs_set_u16(handle, this->key_, code + 1);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to write rolling code: %s", esp_err_to_name(err));
+  }
+
+  nvs_commit(handle);
+  nvs_close(handle);
+
+  ESP_LOGD(TAG, "Rolling code for '%s': %u", this->key_, code);
+  return code;
+}
+
+}  // namespace somfy_cover
+}  // namespace esphome

--- a/esphome/components/somfy_cover/NVSRollingCodeStorage.h
+++ b/esphome/components/somfy_cover/NVSRollingCodeStorage.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "RollingCodeStorage.h"
+
+namespace esphome {
+namespace somfy_cover {
+
+class NVSRollingCodeStorage : public RollingCodeStorage {
+ public:
+  NVSRollingCodeStorage(const char *ns, const char *key) : ns_(ns), key_(key) {}
+  uint16_t next_code() override;
+
+ private:
+  const char *ns_;
+  const char *key_;
+};
+
+}  // namespace somfy_cover
+}  // namespace esphome

--- a/esphome/components/somfy_cover/RollingCodeStorage.h
+++ b/esphome/components/somfy_cover/RollingCodeStorage.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome {
+namespace somfy_cover {
+
+class RollingCodeStorage {
+ public:
+  virtual ~RollingCodeStorage() = default;
+  virtual uint16_t next_code() = 0;
+};
+
+}  // namespace somfy_cover
+}  // namespace esphome

--- a/esphome/components/somfy_cover/cover.py
+++ b/esphome/components/somfy_cover/cover.py
@@ -1,13 +1,10 @@
 import esphome.codegen as cg
-from esphome.components import button, cc1101, cover
+from esphome.components import button, cover, remote_transmitter
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CLOSE_DURATION,
     CONF_ID,
     CONF_OPEN_DURATION,
-    PLATFORM_ESP32,
-    PLATFORM_ESP8266,
-    PLATFORM_RP2040,
 )
 
 CODEOWNERS = ["@HarmEllis"]
@@ -19,10 +16,11 @@ DEPENDENCIES = ["esp32"]
 somfy_cover_ns = cg.esphome_ns.namespace("somfy_cover")
 SomfyCover = somfy_cover_ns.class_("SomfyCover", cover.Cover, cg.Component)
 
-CONF_CC1101_MODULE = "cc1101_module"
+CONF_REMOTE_TRANSMITTER = "remote_transmitter"
 CONF_PROG_BUTTON = "prog_button"
 CONF_REMOTE_CODE = "remote_code"
 CONF_SOMFY_STORAGE_KEY = "storage_key"
+CONF_SOMFY_STORAGE_NAMESPACE = "storage_namespace"
 CONF_REPEAT_COMMAND_COUNT = "repeat_command_count"
 
 CONFIG_SCHEMA = cv.All(
@@ -31,38 +29,41 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(SomfyCover),
             cv.Required(CONF_PROG_BUTTON): cv.use_id(button.Button),
-            cv.Required(CONF_CC1101_MODULE): cv.use_id(cc1101.CC1101),
+            cv.Required(CONF_REMOTE_TRANSMITTER): cv.use_id(
+                remote_transmitter.RemoteTransmitterComponent
+            ),
             cv.Required(CONF_OPEN_DURATION): cv.positive_time_period_milliseconds,
             cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
             cv.Required(CONF_REMOTE_CODE): cv.uint32_t,
-            cv.Required(CONF_SOMFY_STORAGE_KEY): cv.All(cv.string, cv.Length(max=15)),
-            cv.Optional(CONF_REPEAT_COMMAND_COUNT, default=4): cv.int_range(min=1, max=100),
+            cv.Required(CONF_SOMFY_STORAGE_KEY): cv.All(
+                cv.string, cv.Length(max=15)
+            ),
+            cv.Optional(
+                CONF_SOMFY_STORAGE_NAMESPACE, default="somfy_cover"
+            ): cv.All(cv.string, cv.Length(max=15)),
+            cv.Optional(CONF_REPEAT_COMMAND_COUNT, default=4): cv.int_range(
+                min=1, max=100
+            ),
         }
-    ).extend(cv.COMPONENT_SCHEMA),
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
-    cv.only_with_arduino,
+    )
+    .extend(cv.COMPONENT_SCHEMA),
 )
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    cg.add_library("EEPROM", None)
-    cg.add_library("Somfy_Remote_Lib", "0.4.1")
     await cg.register_component(var, config)
     await cover.register_cover(var, config)
 
-    cc1101_module = await cg.get_variable(config[CONF_CC1101_MODULE])
-    cg.add(var.set_cc1101_module(cc1101_module))
+    transmitter = await cg.get_variable(config[CONF_REMOTE_TRANSMITTER])
+    cg.add(var.set_remote_transmitter(transmitter))
 
     btn = await cg.get_variable(config[CONF_PROG_BUTTON])
     cg.add(var.set_prog_button(btn))
 
     cg.add(var.set_open_duration(config[CONF_OPEN_DURATION]))
-
     cg.add(var.set_close_duration(config[CONF_CLOSE_DURATION]))
-
     cg.add(var.set_remote_code(config[CONF_REMOTE_CODE]))
-
     cg.add(var.set_storage_key(config[CONF_SOMFY_STORAGE_KEY]))
-
+    cg.add(var.set_storage_namespace(config[CONF_SOMFY_STORAGE_NAMESPACE]))
     cg.add(var.set_repeat_count(config[CONF_REPEAT_COMMAND_COUNT]))

--- a/esphome/components/somfy_cover/somfy_cover.cpp
+++ b/esphome/components/somfy_cover/somfy_cover.cpp
@@ -6,32 +6,25 @@ namespace somfy_cover {
 
 static const char *TAG = "somfy_cover.cover";
 
-// Default value
-bool cc1101I_initialized = false;
-
 void SomfyCover::setup() {
   // Setup cover rolling code storage
-  this->storage_ = new NVSRollingCodeStorage(NVS_ROLLING_CODE_STORAGE, this->storage_key_);
-
-  // Setup the Somfy Remote
-  this->remote_ = new SomfyRemote(this->cc1101_module_->get_emitter_pin(), this->remote_code_, this->storage_);
-  this->remote_->setup();
+  this->storage_ = new NVSRollingCodeStorage(this->storage_namespace_, this->storage_key_);
 
   // Attach to timebased cover controls
   automationTriggerUp_ = new Automation<>(this->get_open_trigger());
-  actionTriggerUp = new SomfyCoverAction<>([=, this] { return this->open(); });
-  automationTriggerUp_->add_action(actionTriggerUp);
+  actionTriggerUp_ = new SomfyCoverAction<>([this] { this->open(); });
+  automationTriggerUp_->add_action(actionTriggerUp_);
 
   automationTriggerDown_ = new Automation<>(this->get_close_trigger());
-  actionTriggerDown_ = new SomfyCoverAction<>([=, this] { return this->close(); });
+  actionTriggerDown_ = new SomfyCoverAction<>([this] { this->close(); });
   automationTriggerDown_->add_action(actionTriggerDown_);
 
   automationTriggerStop_ = new Automation<>(this->get_stop_trigger());
-  actionTriggerStop_ = new SomfyCoverAction<>([=, this] { return this->stop(); });
+  actionTriggerStop_ = new SomfyCoverAction<>([this] { this->stop(); });
   automationTriggerStop_->add_action(actionTriggerStop_);
 
   // Attach the prog button
-  this->cover_prog_button_->add_on_press_callback([=, this] { return this->program(); });
+  this->cover_prog_button_->add_on_press_callback([this] { this->program(); });
 
   // Set extra settings
   this->has_built_in_endstop_ = true;
@@ -42,43 +35,129 @@ void SomfyCover::setup() {
 
 void SomfyCover::loop() { TimeBasedCover::loop(); }
 
-void SomfyCover::dump_config() { ESP_LOGCONFIG(TAG, "Somfy cover"); }
+void SomfyCover::dump_config() {
+  ESP_LOGCONFIG(TAG, "Somfy cover:");
+  ESP_LOGCONFIG(TAG, "  Remote code: 0x%06X", this->remote_code_);
+  ESP_LOGCONFIG(TAG, "  Storage namespace: %s", this->storage_namespace_);
+  ESP_LOGCONFIG(TAG, "  Storage key: %s", this->storage_key_);
+  ESP_LOGCONFIG(TAG, "  Repeat count: %d", this->repeat_count_);
+}
 
 cover::CoverTraits SomfyCover::get_traits() {
   auto traits = TimeBasedCover::get_traits();
   traits.set_supports_tilt(false);
-
   return traits;
 }
 
 void SomfyCover::control(const cover::CoverCall &call) { TimeBasedCover::control(call); }
 
 void SomfyCover::open() {
-  std::string command = "OPEN " + this->get_object_id();
-  ESP_LOGI("somfy", command.c_str());
+  ESP_LOGI(TAG, "OPEN %s", this->get_object_id().c_str());
   this->send_command(Command::Up);
 }
 
 void SomfyCover::close() {
-  std::string command = "CLOSE " + this->get_object_id();
-  ESP_LOGI("somfy", command.c_str());
+  ESP_LOGI(TAG, "CLOSE %s", this->get_object_id().c_str());
   this->send_command(Command::Down);
 }
 
 void SomfyCover::stop() {
-  std::string command = "STOP " + this->get_object_id();
-  ESP_LOGI("somfy", command.c_str());
+  ESP_LOGI(TAG, "STOP %s", this->get_object_id().c_str());
   this->send_command(Command::My);
 }
 
 void SomfyCover::program() {
-  std::string command = "PROG " + this->get_object_id();
-  ESP_LOGI("somfy", command.c_str());
+  ESP_LOGI(TAG, "PROG %s", this->get_object_id().c_str());
   this->send_command(Command::Prog);
 }
 
 void SomfyCover::send_command(Command command) {
-  this->cc1101_module_->sent_command([=, this] { this->remote_->sendCommand(command, this->repeat_count_); });
+  const uint16_t rolling_code = this->storage_->next_code();
+
+  uint8_t frame[7];
+  this->build_frame(frame, command, rolling_code);
+
+  remote_base::RawTimings timings;
+
+  // First frame with wake-up and 2 hardware sync pulses
+  this->build_timings(timings, frame, 2);
+
+  // Repeat frames with 7 hardware sync pulses
+  for (int i = 0; i < this->repeat_count_; i++) {
+    this->build_timings(timings, frame, 7);
+  }
+
+  auto call = this->remote_transmitter_->transmit();
+  call.get_data()->set_data(timings);
+  call.perform();
+}
+
+void SomfyCover::build_frame(uint8_t *frame, Command command, uint16_t rolling_code) {
+  const uint8_t button = static_cast<uint8_t>(command);
+
+  frame[0] = 0xA7;              // Encryption key
+  frame[1] = button << 4;       // Button (high nibble), checksum placeholder (low nibble)
+  frame[2] = rolling_code >> 8; // Rolling code MSB
+  frame[3] = rolling_code;      // Rolling code LSB
+  frame[4] = this->remote_code_ >> 16;  // Remote address byte 0
+  frame[5] = this->remote_code_ >> 8;   // Remote address byte 1
+  frame[6] = this->remote_code_;        // Remote address byte 2
+
+  // Checksum: XOR of all nibbles
+  uint8_t checksum = 0;
+  for (uint8_t i = 0; i < 7; i++) {
+    checksum = checksum ^ frame[i] ^ (frame[i] >> 4);
+  }
+  checksum &= 0x0F;
+  frame[1] |= checksum;
+
+  // Obfuscation: rolling XOR
+  for (uint8_t i = 1; i < 7; i++) {
+    frame[i] ^= frame[i - 1];
+  }
+
+  ESP_LOGD(TAG, "Frame: %02X %02X %02X %02X %02X %02X %02X",
+           frame[0], frame[1], frame[2], frame[3], frame[4], frame[5], frame[6]);
+}
+
+void SomfyCover::build_timings(remote_base::RawTimings &t, uint8_t *frame, uint8_t sync_count) {
+  // Wake-up pulse (only for first frame, sync_count == 2)
+  if (sync_count == 2) {
+    send_high(t, 9415);
+    send_low(t, 9565 + 80000);
+  }
+
+  // Hardware sync pulses
+  for (uint8_t i = 0; i < sync_count; i++) {
+    send_high(t, 4 * SYMBOL);
+    send_low(t, 4 * SYMBOL);
+  }
+
+  // Software sync
+  send_high(t, 4550);
+  send_low(t, SYMBOL);
+
+  // Data: 56 bits (7 bytes), Manchester encoding
+  for (uint8_t i = 0; i < 56; i++) {
+    if (((frame[i / 8] >> (7 - (i % 8))) & 1) == 1) {
+      send_low(t, SYMBOL);
+      send_high(t, SYMBOL);
+    } else {
+      send_high(t, SYMBOL);
+      send_low(t, SYMBOL);
+    }
+  }
+
+  // Inter-frame gap
+  send_low(t, 415 + 30000);
+}
+
+void SomfyCover::send_high(remote_base::RawTimings &t, int32_t duration_usecs) {
+  t.push_back(duration_usecs);
+}
+
+void SomfyCover::send_low(remote_base::RawTimings &t, int32_t duration_usecs) {
+  t.push_back(-duration_usecs);
 }
 
 }  // namespace somfy_cover

--- a/esphome/components/somfy_cover/somfy_cover.h
+++ b/esphome/components/somfy_cover/somfy_cover.h
@@ -4,24 +4,30 @@
 #include "esphome/core/component.h"
 #include "esphome/components/time_based/time_based_cover.h"
 #include "esphome/components/button/button.h"
-#include "esphome/components/cc1101/cc1101.h"
+#include "esphome/components/remote_transmitter/remote_transmitter.h"
+#include "esphome/components/remote_base/remote_base.h"
 
-// Libraries for SomfyRemote
-#include <NVSRollingCodeStorage.h>
-#include <SomfyRemote.h>
+#include "RollingCodeStorage.h"
+#include "NVSRollingCodeStorage.h"
 
 #define COVER_OPEN 1.0f
 #define COVER_CLOSED 0.0f
 
-#define NVS_ROLLING_CODE_STORAGE "somfy_cover"
-
 namespace esphome {
 namespace somfy_cover {
+
+static const uint16_t SYMBOL = 640;  // microseconds
+
+enum class Command : uint8_t {
+  My = 0x1,
+  Up = 0x2,
+  Down = 0x4,
+  Prog = 0x8,
+};
 
 // Helper class to attach cover functions to the time based cover triggers
 template<typename... Ts> class SomfyCoverAction : public Action<Ts...> {
  public:
-  // The function to be called when the action plays.
   std::function<void(Ts...)> callback;
 
   explicit SomfyCoverAction(std::function<void(Ts...)> callback) : callback(callback) {}
@@ -42,14 +48,17 @@ class SomfyCover : public time_based::TimeBasedCover {
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
   void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
 
-  // Set cc1101 module
-  void set_cc1101_module(cc1101::CC1101 *cc1101_module) { this->cc1101_module_ = cc1101_module; }
+  // Set remote transmitter
+  void set_remote_transmitter(remote_transmitter::RemoteTransmitterComponent *transmitter) {
+    this->remote_transmitter_ = transmitter;
+  }
 
-  // Set somfy cover button and value
+  // Set somfy cover button and values
   void set_prog_button(button::Button *cover_prog_button) { this->cover_prog_button_ = cover_prog_button; }
-  void set_remote_code(uint32_t remote_code_) { this->remote_code_ = remote_code_; }
-  void set_storage_key(const char *storage_key_) { this->storage_key_ = storage_key_; }
-  void set_repeat_count(int repeat_count_) { this->repeat_count_ = repeat_count_; }
+  void set_remote_code(uint32_t remote_code) { this->remote_code_ = remote_code; }
+  void set_storage_key(const char *storage_key) { this->storage_key_ = storage_key; }
+  void set_storage_namespace(const char *storage_namespace) { this->storage_namespace_ = storage_namespace; }
+  void set_repeat_count(int repeat_count) { this->repeat_count_ = repeat_count; }
 
   cover::CoverTraits get_traits() override;
 
@@ -57,33 +66,36 @@ class SomfyCover : public time_based::TimeBasedCover {
   void control(const cover::CoverCall &call) override;
 
   // Set via the ESPHome yaml
-  cc1101::CC1101 *cc1101_module_{nullptr};
+  remote_transmitter::RemoteTransmitterComponent *remote_transmitter_{nullptr};
   button::Button *cover_prog_button_{nullptr};
   uint32_t remote_code_{0};
-  const char *storage_key_;
-  int repeat_count_{4};  // Number of times to repeat the command
+  const char *storage_key_{nullptr};
+  const char *storage_namespace_{"somfy_cover"};
+  int repeat_count_{4};
 
-  // Set via the constructor
-  SomfyRemote *remote_;
-  NVSRollingCodeStorage *storage_;
+  // Rolling code storage
+  RollingCodeStorage *storage_{nullptr};
 
   void open();
   void close();
   void stop();
   void program();
 
-  // Create automations to attach the cover control functions
-  Automation<> *automationTriggerUp_;
-  SomfyCoverAction<> *actionTriggerUp;
-  Automation<> *automationTriggerDown_;
-  SomfyCoverAction<> *actionTriggerDown_;
-  Automation<> *automationTriggerStop_;
-  SomfyCoverAction<> *actionTriggerStop_;
-
+  // Somfy RTS protocol
   void send_command(Command command);
-};
+  void build_frame(uint8_t *frame, Command command, uint16_t rolling_code);
+  void build_timings(remote_base::RawTimings &t, uint8_t *frame, uint8_t sync_count);
+  static void send_high(remote_base::RawTimings &t, int32_t duration_usecs);
+  static void send_low(remote_base::RawTimings &t, int32_t duration_usecs);
 
-extern bool cc1101I_initialized;
+  // Create automations to attach the cover control functions
+  Automation<> *automationTriggerUp_{nullptr};
+  SomfyCoverAction<> *actionTriggerUp_{nullptr};
+  Automation<> *automationTriggerDown_{nullptr};
+  SomfyCoverAction<> *actionTriggerDown_{nullptr};
+  Automation<> *automationTriggerStop_{nullptr};
+  SomfyCoverAction<> *actionTriggerStop_{nullptr};
+};
 
 }  // namespace somfy_cover
 }  // namespace esphome


### PR DESCRIPTION
## Summary
- Replace custom CC1101 component (`esphome-cc1101`) and `Somfy_Remote_Lib` Arduino library with native implementations using ESPHome's official CC1101 and Remote Transmitter components
- Implement Somfy RTS frame building and Manchester-encoded RF timing generation natively in C++, with custom NVS rolling code storage using ESP-IDF APIs directly
- Enable ESP-IDF framework support (in addition to Arduino), removing the Arduino-only restriction

## Test plan
- [x] Compile with ESP-IDF framework
- [x] Test cover open/close/stop commands
- [x] Test program button pairing
- [x] Verify rolling codes persist across reboots

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)