### PR TITLE
Vendored `time_based_cover.{cpp,h}` with the external comfy cover component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ esphome:
   name: somfycontroller
 
 external_components:
-  - source: github://HarmEllis/esphome-somfy-cover-remote@main
+  - source: github://CorjanV/esphome-somfy-cover-remote@feature/official-cc1101-remote-transmitter
     components: [ somfy_cover ]
 
 esp32:

--- a/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
+++ b/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
@@ -9,7 +9,7 @@ namespace somfy_cover {
 static const char *TAG = "somfy_cover.nvs";
 
 uint16_t NVSRollingCodeStorage::next_code() {
-  uint16_t code = 1000; // see also nvs_get_u16
+  uint16_t code = 1;
   nvs_handle_t handle;
 
   esp_err_t err = nvs_flash_init();
@@ -31,7 +31,7 @@ uint16_t NVSRollingCodeStorage::next_code() {
 
   err = nvs_get_u16(handle, this->key_, &code);
   if (err == ESP_ERR_NVS_NOT_FOUND) {
-    code = 1000;
+    code = 1;
   } else if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to read rolling code: %s", esp_err_to_name(err));
     nvs_close(handle);

--- a/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
+++ b/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
@@ -9,7 +9,7 @@ namespace somfy_cover {
 static const char *TAG = "somfy_cover.nvs";
 
 uint16_t NVSRollingCodeStorage::next_code() {
-  uint16_t code = 1000;
+  uint16_t code = 1000; // see also nvs_get_u16
   nvs_handle_t handle;
 
   esp_err_t err = nvs_flash_init();
@@ -31,7 +31,7 @@ uint16_t NVSRollingCodeStorage::next_code() {
 
   err = nvs_get_u16(handle, this->key_, &code);
   if (err == ESP_ERR_NVS_NOT_FOUND) {
-    code = 1;
+    code = 1000;
   } else if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to read rolling code: %s", esp_err_to_name(err));
     nvs_close(handle);

--- a/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
+++ b/esphome/components/somfy_cover/NVSRollingCodeStorage.cpp
@@ -9,7 +9,7 @@ namespace somfy_cover {
 static const char *TAG = "somfy_cover.nvs";
 
 uint16_t NVSRollingCodeStorage::next_code() {
-  uint16_t code = 1;
+  uint16_t code = 1000;
   nvs_handle_t handle;
 
   esp_err_t err = nvs_flash_init();

--- a/esphome/components/somfy_cover/cover.py
+++ b/esphome/components/somfy_cover/cover.py
@@ -9,7 +9,7 @@ from esphome.const import (
 
 CODEOWNERS = ["@HarmEllis"]
 
-AUTO_LOAD = ["button", "time_based"]
+AUTO_LOAD = ["button"]
 
 DEPENDENCIES = ["esp32"]
 

--- a/esphome/components/somfy_cover/somfy_cover.cpp
+++ b/esphome/components/somfy_cover/somfy_cover.cpp
@@ -52,22 +52,26 @@ cover::CoverTraits SomfyCover::get_traits() {
 void SomfyCover::control(const cover::CoverCall &call) { TimeBasedCover::control(call); }
 
 void SomfyCover::open() {
-  ESP_LOGI(TAG, "OPEN %s", this->get_object_id().c_str());
+  char object_id[OBJECT_ID_MAX_LEN];
+  ESP_LOGI(TAG, "OPEN %s", this->get_object_id_to(object_id).c_str());
   this->send_command(Command::Up);
 }
 
 void SomfyCover::close() {
-  ESP_LOGI(TAG, "CLOSE %s", this->get_object_id().c_str());
+  char object_id[OBJECT_ID_MAX_LEN];
+  ESP_LOGI(TAG, "CLOSE %s", this->get_object_id_to(object_id).c_str());
   this->send_command(Command::Down);
 }
 
 void SomfyCover::stop() {
-  ESP_LOGI(TAG, "STOP %s", this->get_object_id().c_str());
+  char object_id[OBJECT_ID_MAX_LEN];
+  ESP_LOGI(TAG, "STOP %s", this->get_object_id_to(object_id).c_str());
   this->send_command(Command::My);
 }
 
 void SomfyCover::program() {
-  ESP_LOGI(TAG, "PROG %s", this->get_object_id().c_str());
+  char object_id[OBJECT_ID_MAX_LEN];
+  ESP_LOGI(TAG, "PROG %s", this->get_object_id_to(object_id).c_str());
   this->send_command(Command::Prog);
 }
 

--- a/esphome/components/somfy_cover/somfy_cover.h
+++ b/esphome/components/somfy_cover/somfy_cover.h
@@ -9,6 +9,7 @@
 
 #include "RollingCodeStorage.h"
 #include "NVSRollingCodeStorage.h"
+#include "time_based_cover.h"
 
 #define COVER_OPEN 1.0f
 #define COVER_CLOSED 0.0f
@@ -38,7 +39,7 @@ template<typename... Ts> class SomfyCoverAction : public Action<Ts...> {
   }
 };
 
-class SomfyCover : public time_based::TimeBasedCover {
+class SomfyCover : public time_based_somfy_cover::TimeBasedCover {
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/somfy_cover/somfy_cover.h
+++ b/esphome/components/somfy_cover/somfy_cover.h
@@ -2,7 +2,6 @@
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
-#include "esphome/components/time_based/time_based_cover.h"
 #include "esphome/components/button/button.h"
 #include "esphome/components/remote_transmitter/remote_transmitter.h"
 #include "esphome/components/remote_base/remote_base.h"

--- a/esphome/components/somfy_cover/time_based_cover.cpp
+++ b/esphome/components/somfy_cover/time_based_cover.cpp
@@ -1,0 +1,187 @@
+#include "time_based_cover.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace time_based {
+
+static const char *const TAG = "time_based.cover";
+
+using namespace esphome::cover;
+
+void TimeBasedCover::dump_config() {
+  LOG_COVER("", "Time Based Cover", this);
+  ESP_LOGCONFIG(TAG,
+                "  Open Duration: %.1fs\n"
+                "  Close Duration: %.1fs",
+                this->open_duration_ / 1e3f, this->close_duration_ / 1e3f);
+}
+void TimeBasedCover::setup() {
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->apply(this);
+  } else {
+    this->position = 0.5f;
+  }
+}
+void TimeBasedCover::loop() {
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
+
+  const uint32_t now = App.get_loop_component_start_time();
+
+  // Recompute position every loop cycle
+  this->recompute_position_();
+
+  if (this->is_at_target_()) {
+    if (this->has_built_in_endstop_ &&
+        (this->target_position_ == COVER_OPEN || this->target_position_ == COVER_CLOSED)) {
+      // Don't trigger stop, let the cover stop by itself.
+      this->current_operation = COVER_OPERATION_IDLE;
+    } else {
+      this->start_direction_(COVER_OPERATION_IDLE);
+    }
+    this->publish_state();
+  }
+
+  // Send current position every second
+  if (now - this->last_publish_time_ > 1000) {
+    this->publish_state(false);
+    this->last_publish_time_ = now;
+  }
+}
+
+CoverTraits TimeBasedCover::get_traits() {
+  auto traits = CoverTraits();
+  traits.set_supports_stop(true);
+  traits.set_supports_position(true);
+  traits.set_supports_toggle(true);
+  traits.set_is_assumed_state(this->assumed_state_);
+  return traits;
+}
+void TimeBasedCover::control(const CoverCall &call) {
+  if (call.get_stop()) {
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->publish_state();
+  }
+  if (call.get_toggle().has_value()) {
+    if (this->current_operation != COVER_OPERATION_IDLE) {
+      this->start_direction_(COVER_OPERATION_IDLE);
+      this->publish_state();
+    } else {
+      if (this->position == COVER_CLOSED || this->last_operation_ == COVER_OPERATION_CLOSING) {
+        this->target_position_ = COVER_OPEN;
+        this->start_direction_(COVER_OPERATION_OPENING);
+      } else {
+        this->target_position_ = COVER_CLOSED;
+        this->start_direction_(COVER_OPERATION_CLOSING);
+      }
+    }
+  }
+  auto pos_val = call.get_position();
+  if (pos_val.has_value()) {
+    auto pos = *pos_val;
+    if (pos == this->position) {
+      // already at target
+      if (this->manual_control_ && (pos == COVER_OPEN || pos == COVER_CLOSED)) {
+        // for covers with manual control switch, we can't rely on the computed position, so if
+        // the command triggered again, we'll assume it's in the opposite direction anyway.
+        auto op = pos == COVER_CLOSED ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+        this->position = pos == COVER_CLOSED ? COVER_OPEN : COVER_CLOSED;
+        this->target_position_ = pos;
+        this->start_direction_(op);
+      }
+      // for covers with built in end stop, we should send the command again
+      if (this->has_built_in_endstop_ && (pos == COVER_OPEN || pos == COVER_CLOSED)) {
+        auto op = pos == COVER_CLOSED ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+        this->target_position_ = pos;
+        this->start_direction_(op);
+      }
+    } else {
+      auto op = pos < this->position ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+      if (this->manual_control_ && (pos == COVER_OPEN || pos == COVER_CLOSED)) {
+        this->position = pos == COVER_CLOSED ? COVER_OPEN : COVER_CLOSED;
+      }
+      this->target_position_ = pos;
+      this->start_direction_(op);
+    }
+  }
+}
+void TimeBasedCover::stop_prev_trigger_() {
+  if (this->prev_command_trigger_ != nullptr) {
+    this->prev_command_trigger_->stop_action();
+    this->prev_command_trigger_ = nullptr;
+  }
+}
+bool TimeBasedCover::is_at_target_() const {
+  switch (this->current_operation) {
+    case COVER_OPERATION_OPENING:
+      return this->position >= this->target_position_;
+    case COVER_OPERATION_CLOSING:
+      return this->position <= this->target_position_;
+    case COVER_OPERATION_IDLE:
+    default:
+      return true;
+  }
+}
+void TimeBasedCover::start_direction_(CoverOperation dir) {
+  if (dir == this->current_operation && dir != COVER_OPERATION_IDLE)
+    return;
+
+  this->recompute_position_();
+  Trigger<> *trig;
+  switch (dir) {
+    case COVER_OPERATION_IDLE:
+      trig = &this->stop_trigger_;
+      break;
+    case COVER_OPERATION_OPENING:
+      this->last_operation_ = dir;
+      trig = &this->open_trigger_;
+      break;
+    case COVER_OPERATION_CLOSING:
+      this->last_operation_ = dir;
+      trig = &this->close_trigger_;
+      break;
+    default:
+      return;
+  }
+
+  this->current_operation = dir;
+
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
+  this->last_recompute_time_ = now;
+
+  this->stop_prev_trigger_();
+  trig->trigger();
+  this->prev_command_trigger_ = trig;
+}
+void TimeBasedCover::recompute_position_() {
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
+
+  float dir;
+  float action_dur;
+  switch (this->current_operation) {
+    case COVER_OPERATION_OPENING:
+      dir = 1.0f;
+      action_dur = this->open_duration_;
+      break;
+    case COVER_OPERATION_CLOSING:
+      dir = -1.0f;
+      action_dur = this->close_duration_;
+      break;
+    default:
+      return;
+  }
+
+  const uint32_t now = millis();
+  this->position += dir * (now - this->last_recompute_time_) / action_dur;
+  this->position = clamp(this->position, 0.0f, 1.0f);
+
+  this->last_recompute_time_ = now;
+}
+
+}  // namespace time_based
+}  // namespace esphome

--- a/esphome/components/somfy_cover/time_based_cover.cpp
+++ b/esphome/components/somfy_cover/time_based_cover.cpp
@@ -4,7 +4,7 @@
 #include "esphome/core/application.h"
 
 namespace esphome {
-namespace time_based {
+namespace time_based_somfy_cover {
 
 static const char *const TAG = "time_based.cover";
 
@@ -183,5 +183,5 @@ void TimeBasedCover::recompute_position_() {
   this->last_recompute_time_ = now;
 }
 
-}  // namespace time_based
+}  // namespace time_based_somfy_cover
 }  // namespace esphome

--- a/esphome/components/somfy_cover/time_based_cover.cpp
+++ b/esphome/components/somfy_cover/time_based_cover.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "time_based.cover";
 using namespace esphome::cover;
 
 void TimeBasedCover::dump_config() {
-  LOG_COVER("", "Time Based Cover", this);
+  LOG_COVER("", "Time Based Somfy Cover", this);
   ESP_LOGCONFIG(TAG,
                 "  Open Duration: %.1fs\n"
                 "  Close Duration: %.1fs",

--- a/esphome/components/somfy_cover/time_based_cover.h
+++ b/esphome/components/somfy_cover/time_based_cover.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/cover/cover.h"
+
+namespace esphome {
+namespace time_based_somfy_cover {
+
+class TimeBasedCover : public cover::Cover, public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  Trigger<> *get_open_trigger() { return &this->open_trigger_; }
+  Trigger<> *get_close_trigger() { return &this->close_trigger_; }
+  Trigger<> *get_stop_trigger() { return &this->stop_trigger_; }
+  void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
+  void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
+  cover::CoverTraits get_traits() override;
+  void set_has_built_in_endstop(bool value) { this->has_built_in_endstop_ = value; }
+  void set_manual_control(bool value) { this->manual_control_ = value; }
+  void set_assumed_state(bool value) { this->assumed_state_ = value; }
+  cover::CoverOperation get_last_operation() const { return this->last_operation_; }
+
+ protected:
+  void control(const cover::CoverCall &call) override;
+  void stop_prev_trigger_();
+  bool is_at_target_() const;
+
+  void start_direction_(cover::CoverOperation dir);
+
+  void recompute_position_();
+
+  Trigger<> open_trigger_;
+  uint32_t open_duration_;
+  Trigger<> close_trigger_;
+  uint32_t close_duration_;
+  Trigger<> stop_trigger_;
+
+  Trigger<> *prev_command_trigger_{nullptr};
+  uint32_t last_recompute_time_{0};
+  uint32_t start_dir_time_{0};
+  uint32_t last_publish_time_{0};
+  float target_position_{0};
+  bool has_built_in_endstop_{false};
+  bool manual_control_{false};
+  bool assumed_state_{false};
+  cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
+};
+
+}  // namespace time_based_somfy_cover
+}  // namespace esphome


### PR DESCRIPTION
I vendored `time_based_cover.{cpp,h}` with the external somfy cover component, since [from ESPHome version 2026.4.x somfy cover component cannot be compiled.](https://github.com/esphome/esphome/issues/15872)
