### PR TITLE
Add tilt commands and generic send action

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,6 +36,7 @@ Old `cover.platform=somfy_cover` fields -> New location
 - `storage_key` -> `somfy_rts.storage_key`
 - `storage_namespace` -> `somfy_rts.storage_namespace`
 - `repeat_command_count` -> `somfy_rts.repeat_command_count`
+- `tilt_repeat_count` -> `somfy_rts.tilt_repeat_count`
 - `prog_button` -> optional `somfy_rts.prog_button` (or call `somfy_rts.program` in automations)
 - `open_duration` -> `cover.platform=time_based.open_duration`
 - `close_duration` -> `cover.platform=time_based.close_duration`
@@ -61,7 +62,8 @@ somfy_rts:
     remote_code: 0x6b2a03
     storage_key: "livingroom"
     storage_namespace: "somfy_cover"
-    repeat_command_count: 4
+    repeat_command_count: 1
+    tilt_repeat_count: 3
 
 cover:
   - platform: time_based

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ These actions can be used in automations, including `time_based` cover actions:
 - `somfy_rts.program`
 - `somfy_rts.open_tilt`
 - `somfy_rts.close_tilt`
+- `somfy_rts.send` (generic command — see [Generic send action](#generic-send-action))
 
 Examples:
 
@@ -197,6 +198,40 @@ cover:
 ```
 
 If tilt does not work with the default `tilt_repeat_count: 3`, sweep values `1..4` for your louvre model.
+
+## Generic send action
+
+For commands that do not map to the high-level actions — for example "long program" (used to pair a second remote) or experimenting with non-standard repeat counts — use `somfy_rts.send`:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `id` | Yes | | ID of the `somfy_rts` instance |
+| `command` | Yes | | One of `UP`, `DOWN`, `MY`, `PROG` |
+| `repeat_count` | No | `repeat_command_count` | Templatable integer (1-100). Overrides the configured `repeat_command_count` for this single call. |
+
+Example — long program (15 repeats of `PROG`) to add an extra remote to an already-paired motor:
+
+```yaml
+button:
+  - platform: template
+    name: "Pair extra remote"
+    on_press:
+      - somfy_rts.send:
+          id: livingroom_cmd
+          command: PROG
+          repeat_count: 15
+```
+
+Example — templatable repeat count:
+
+```yaml
+on_...:
+  then:
+    - somfy_rts.send:
+        id: livingroom_cmd
+        command: UP
+        repeat_count: !lambda 'return id(tilt_steps).state;'
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ cover:
 | `storage_key` | Yes | | Key for rolling code storage in NVS (max 15 chars, unique per cover) |
 | `storage_namespace` | No | `somfy_rts` | NVS namespace for rolling code storage (max 15 chars) |
 | `repeat_command_count` | No | `4` | Number of repeated frames after the first frame (1-100) |
+| `tilt_repeat_count` | No | `3` | Number of repeated frames for `open_tilt` / `close_tilt` (1-100). Same semantics as `repeat_command_count` (one initial frame + N repeats). Some louvres need a different value — if tilt does not work, sweep `1..4`. |
 | `prog_button` | No | | Optional `button` ID. If set, pressing that button sends `PROG` |
 
 ## Actions
@@ -123,6 +124,8 @@ These actions can be used in automations, including `time_based` cover actions:
 - `somfy_rts.close`
 - `somfy_rts.stop`
 - `somfy_rts.program`
+- `somfy_rts.open_tilt`
+- `somfy_rts.close_tilt`
 
 Examples:
 
@@ -153,6 +156,47 @@ Put your cover in program mode with an already paired remote, then send `PROG` f
 ## Repeating command setting
 
 Default behavior is to send one initial frame + repeated frames (`repeat_command_count`, default `4`). Some devices require fewer repeats.
+
+## Tilt commands
+
+Somfy RTS louvre covers tilt by sending the same `UP` / `DOWN` command but with a lower number of repeated frames. The `somfy_rts.open_tilt` and `somfy_rts.close_tilt` actions send `UP` / `DOWN` using `tilt_repeat_count` (default `3`) instead of `repeat_command_count`.
+
+The official ESPHome `time_based` cover platform has no tilt hooks, so wire these actions to your own controls. Two common patterns:
+
+### Template buttons (simple)
+
+```yaml
+button:
+  - platform: template
+    name: "Livingroom tilt open"
+    on_press:
+      - somfy_rts.open_tilt: livingroom_cmd
+  - platform: template
+    name: "Livingroom tilt close"
+    on_press:
+      - somfy_rts.close_tilt: livingroom_cmd
+```
+
+### Template cover with `tilt_action` (advanced)
+
+```yaml
+cover:
+  - platform: template
+    name: "Livingroom louvre tilt"
+    device_class: shutter
+    optimistic: true   # no tilt feedback from the motor
+    has_position: false
+    tilt_action:
+      - if:
+          condition:
+            lambda: 'return tilt > 0.5;'
+          then:
+            - somfy_rts.open_tilt: livingroom_cmd
+          else:
+            - somfy_rts.close_tilt: livingroom_cmd
+```
+
+If tilt does not work with the default `tilt_repeat_count: 3`, sweep values `1..4` for your louvre model.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ somfy_rts:
     remote_code: 0x6b2a03
     storage_key: "livingroom"
     storage_namespace: "somfy_rts"
-    repeat_command_count: 4
+    repeat_command_count: 1
+    tilt_repeat_count: 3
     prog_button: program_livingroom
 
 cover:
@@ -112,8 +113,8 @@ cover:
 | `remote_code` | Yes | | Unique 3-byte hex remote code (e.g. `0x6b2a03`) |
 | `storage_key` | Yes | | Key for rolling code storage in NVS (max 15 chars, unique per cover) |
 | `storage_namespace` | No | `somfy_rts` | NVS namespace for rolling code storage (max 15 chars) |
-| `repeat_command_count` | No | `4` | Number of repeated frames after the first frame (1-100) |
-| `tilt_repeat_count` | No | `3` | Number of repeated frames for `open_tilt` / `close_tilt` (1-100). Same semantics as `repeat_command_count` (one initial frame + N repeats). Some louvres need a different value — if tilt does not work, sweep `1..4`. |
+| `repeat_command_count` | No | `4` | Number of repeated frames after the first frame (0-100). Set to `0` to send only the initial frame. |
+| `tilt_repeat_count` | No | `3` | Number of repeated frames for `open_tilt` / `close_tilt` (0-100). Same semantics as `repeat_command_count` (one initial frame + N repeats). Some louvres need a different value; if tilt does not work, sweep `0..4`. |
 | `prog_button` | No | | Optional `button` ID. If set, pressing that button sends `PROG` |
 
 ## Actions
@@ -156,7 +157,7 @@ Put your cover in program mode with an already paired remote, then send `PROG` f
 
 ## Repeating command setting
 
-Default behavior is to send one initial frame + repeated frames (`repeat_command_count`, default `4`). Some devices require fewer repeats.
+Default behavior is to send one initial frame + repeated frames (`repeat_command_count`, default `4`). Some devices require fewer repeats, including `repeat_command_count: 0` to send only the initial frame.
 
 ## Tilt commands
 
@@ -197,7 +198,7 @@ cover:
             - somfy_rts.close_tilt: livingroom_cmd
 ```
 
-If tilt does not work with the default `tilt_repeat_count: 3`, sweep values `1..4` for your louvre model.
+If tilt does not work with the default `tilt_repeat_count: 3`, sweep values `0..4` for your louvre model.
 
 ## Generic send action
 
@@ -207,7 +208,7 @@ For commands that do not map to the high-level actions — for example "long pro
 |-------|----------|---------|-------------|
 | `id` | Yes | | ID of the `somfy_rts` instance |
 | `command` | Yes | | One of `UP`, `DOWN`, `MY`, `PROG` |
-| `repeat_count` | No | `repeat_command_count` | Templatable integer (1-100). Overrides the configured `repeat_command_count` for this single call. |
+| `repeat_count` | No | `repeat_command_count` | Templatable integer (0-100). Overrides the configured `repeat_command_count` for this single call. |
 
 Example — long program (15 repeats of `PROG`) to add an extra remote to an already-paired motor:
 

--- a/esphome/components/somfy_rts/__init__.py
+++ b/esphome/components/somfy_rts/__init__.py
@@ -49,8 +49,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_SOMFY_STORAGE_NAMESPACE, default="somfy_rts"): cv.All(
             cv.string, cv.Length(max=15)
         ),
-        cv.Optional(CONF_REPEAT_COMMAND_COUNT, default=4): cv.int_range(min=1, max=100),
-        cv.Optional(CONF_TILT_REPEAT_COUNT, default=3): cv.int_range(min=1, max=100),
+        cv.Optional(CONF_REPEAT_COMMAND_COUNT, default=4): cv.int_range(min=0, max=100),
+        cv.Optional(CONF_TILT_REPEAT_COUNT, default=3): cv.int_range(min=0, max=100),
         cv.Optional(CONF_PROG_BUTTON): cv.use_id(button.Button),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -106,7 +106,7 @@ SOMFY_SEND_ACTION_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ID): cv.use_id(SomfyRts),
         cv.Required(CONF_COMMAND): cv.enum(COMMAND_MAP, upper=True),
-        cv.Optional(CONF_REPEAT_COUNT): cv.templatable(cv.int_range(min=1, max=100)),
+        cv.Optional(CONF_REPEAT_COUNT): cv.templatable(cv.int_range(min=0, max=100)),
     }
 )
 

--- a/esphome/components/somfy_rts/__init__.py
+++ b/esphome/components/somfy_rts/__init__.py
@@ -12,12 +12,21 @@ MULTI_CONF = True
 somfy_rts_ns = cg.esphome_ns.namespace("somfy_rts")
 SomfyRts = somfy_rts_ns.class_("SomfyRts", cg.Component)
 
+Command = somfy_rts_ns.enum("Command", is_class=True)
+COMMAND_MAP = {
+    "UP": Command.Up,
+    "DOWN": Command.Down,
+    "MY": Command.My,
+    "PROG": Command.Prog,
+}
+
 OpenAction = somfy_rts_ns.class_("OpenAction", automation.Action)
 CloseAction = somfy_rts_ns.class_("CloseAction", automation.Action)
 StopAction = somfy_rts_ns.class_("StopAction", automation.Action)
 ProgramAction = somfy_rts_ns.class_("ProgramAction", automation.Action)
 OpenTiltAction = somfy_rts_ns.class_("OpenTiltAction", automation.Action)
 CloseTiltAction = somfy_rts_ns.class_("CloseTiltAction", automation.Action)
+SendAction = somfy_rts_ns.class_("SendAction", automation.Action)
 
 CONF_REMOTE_TRANSMITTER = "remote_transmitter"
 CONF_PROG_BUTTON = "prog_button"
@@ -26,6 +35,8 @@ CONF_SOMFY_STORAGE_KEY = "storage_key"
 CONF_SOMFY_STORAGE_NAMESPACE = "storage_namespace"
 CONF_REPEAT_COMMAND_COUNT = "repeat_command_count"
 CONF_TILT_REPEAT_COUNT = "tilt_repeat_count"
+CONF_COMMAND = "command"
+CONF_REPEAT_COUNT = "repeat_count"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -89,3 +100,25 @@ SOMFY_ACTION_SCHEMA = cv.Schema(
 async def somfy_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, parent)
+
+
+SOMFY_SEND_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.use_id(SomfyRts),
+        cv.Required(CONF_COMMAND): cv.enum(COMMAND_MAP, upper=True),
+        cv.Optional(CONF_REPEAT_COUNT): cv.templatable(cv.int_range(min=1, max=100)),
+    }
+)
+
+
+@automation.register_action(
+    "somfy_rts.send", SendAction, SOMFY_SEND_ACTION_SCHEMA, synchronous=True
+)
+async def somfy_send_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    cg.add(var.set_command(config[CONF_COMMAND]))
+    if CONF_REPEAT_COUNT in config:
+        templ = await cg.templatable(config[CONF_REPEAT_COUNT], args, cg.int_)
+        cg.add(var.set_repeat_count(templ))
+    return var

--- a/esphome/components/somfy_rts/__init__.py
+++ b/esphome/components/somfy_rts/__init__.py
@@ -16,6 +16,8 @@ OpenAction = somfy_rts_ns.class_("OpenAction", automation.Action)
 CloseAction = somfy_rts_ns.class_("CloseAction", automation.Action)
 StopAction = somfy_rts_ns.class_("StopAction", automation.Action)
 ProgramAction = somfy_rts_ns.class_("ProgramAction", automation.Action)
+OpenTiltAction = somfy_rts_ns.class_("OpenTiltAction", automation.Action)
+CloseTiltAction = somfy_rts_ns.class_("CloseTiltAction", automation.Action)
 
 CONF_REMOTE_TRANSMITTER = "remote_transmitter"
 CONF_PROG_BUTTON = "prog_button"
@@ -23,6 +25,7 @@ CONF_REMOTE_CODE = "remote_code"
 CONF_SOMFY_STORAGE_KEY = "storage_key"
 CONF_SOMFY_STORAGE_NAMESPACE = "storage_namespace"
 CONF_REPEAT_COMMAND_COUNT = "repeat_command_count"
+CONF_TILT_REPEAT_COUNT = "tilt_repeat_count"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -36,6 +39,7 @@ CONFIG_SCHEMA = cv.Schema(
             cv.string, cv.Length(max=15)
         ),
         cv.Optional(CONF_REPEAT_COMMAND_COUNT, default=4): cv.int_range(min=1, max=100),
+        cv.Optional(CONF_TILT_REPEAT_COUNT, default=3): cv.int_range(min=1, max=100),
         cv.Optional(CONF_PROG_BUTTON): cv.use_id(button.Button),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -56,6 +60,7 @@ async def to_code(config):
     cg.add(var.set_storage_key(config[CONF_SOMFY_STORAGE_KEY]))
     cg.add(var.set_storage_namespace(config[CONF_SOMFY_STORAGE_NAMESPACE]))
     cg.add(var.set_repeat_count(config[CONF_REPEAT_COMMAND_COUNT]))
+    cg.add(var.set_tilt_repeat_count(config[CONF_TILT_REPEAT_COUNT]))
 
 
 SOMFY_ACTION_SCHEMA = cv.Schema(
@@ -74,6 +79,12 @@ SOMFY_ACTION_SCHEMA = cv.Schema(
 )
 @automation.register_action(
     "somfy_rts.program", ProgramAction, SOMFY_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "somfy_rts.open_tilt", OpenTiltAction, SOMFY_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "somfy_rts.close_tilt", CloseTiltAction, SOMFY_ACTION_SCHEMA, synchronous=True
 )
 async def somfy_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/somfy_rts/somfy_rts.cpp
+++ b/esphome/components/somfy_rts/somfy_rts.cpp
@@ -69,7 +69,19 @@ void SomfyRts::send_command(Command command, int repeat_count) {
     return;
   }
 
-  const int effective_repeat_count = repeat_count < 0 ? this->repeat_count_ : repeat_count;
+  int effective_repeat_count;
+  if (repeat_count < 0) {
+    // Internal sentinel: use the configured default
+    effective_repeat_count = this->repeat_count_;
+  } else if (repeat_count < 1) {
+    ESP_LOGW(TAG, "repeat_count %d below 1, clamping to 1", repeat_count);
+    effective_repeat_count = 1;
+  } else if (repeat_count > 100) {
+    ESP_LOGW(TAG, "repeat_count %d above 100, clamping to 100", repeat_count);
+    effective_repeat_count = 100;
+  } else {
+    effective_repeat_count = repeat_count;
+  }
   ESP_LOGD(TAG, "Repeat count: %d", effective_repeat_count);
 
   const uint16_t rolling_code = this->storage_->next_code();

--- a/esphome/components/somfy_rts/somfy_rts.cpp
+++ b/esphome/components/somfy_rts/somfy_rts.cpp
@@ -58,7 +58,22 @@ void SomfyRts::close_tilt() {
   this->send_command(Command::Down, this->tilt_repeat_count_);
 }
 
+void SomfyRts::send_command(Command command) {
+  this->send_command_impl_(command, this->repeat_count_);
+}
+
 void SomfyRts::send_command(Command command, int repeat_count) {
+  if (repeat_count < 1) {
+    ESP_LOGW(TAG, "repeat_count %d below 1, clamping to 1", repeat_count);
+    repeat_count = 1;
+  } else if (repeat_count > 100) {
+    ESP_LOGW(TAG, "repeat_count %d above 100, clamping to 100", repeat_count);
+    repeat_count = 100;
+  }
+  this->send_command_impl_(command, repeat_count);
+}
+
+void SomfyRts::send_command_impl_(Command command, int repeat_count) {
   if (this->remote_transmitter_ == nullptr) {
     ESP_LOGE(TAG, "No remote_transmitter configured");
     return;
@@ -69,20 +84,7 @@ void SomfyRts::send_command(Command command, int repeat_count) {
     return;
   }
 
-  int effective_repeat_count;
-  if (repeat_count < 0) {
-    // Internal sentinel: use the configured default
-    effective_repeat_count = this->repeat_count_;
-  } else if (repeat_count < 1) {
-    ESP_LOGW(TAG, "repeat_count %d below 1, clamping to 1", repeat_count);
-    effective_repeat_count = 1;
-  } else if (repeat_count > 100) {
-    ESP_LOGW(TAG, "repeat_count %d above 100, clamping to 100", repeat_count);
-    effective_repeat_count = 100;
-  } else {
-    effective_repeat_count = repeat_count;
-  }
-  ESP_LOGD(TAG, "Repeat count: %d", effective_repeat_count);
+  ESP_LOGD(TAG, "Repeat count: %d", repeat_count);
 
   const uint16_t rolling_code = this->storage_->next_code();
 
@@ -95,7 +97,7 @@ void SomfyRts::send_command(Command command, int repeat_count) {
   this->build_timings(timings, frame, 2);
 
   // Repeat frames with 7 hardware sync pulses
-  for (int i = 0; i < effective_repeat_count; i++) {
+  for (int i = 0; i < repeat_count; i++) {
     this->build_timings(timings, frame, 7);
   }
 

--- a/esphome/components/somfy_rts/somfy_rts.cpp
+++ b/esphome/components/somfy_rts/somfy_rts.cpp
@@ -24,6 +24,7 @@ void SomfyRts::dump_config() {
   ESP_LOGCONFIG(TAG, "  Storage namespace: %s", this->storage_namespace_);
   ESP_LOGCONFIG(TAG, "  Storage key: %s", this->storage_key_);
   ESP_LOGCONFIG(TAG, "  Repeat count: %d", this->repeat_count_);
+  ESP_LOGCONFIG(TAG, "  Tilt repeat count: %d", this->tilt_repeat_count_);
   ESP_LOGCONFIG(TAG, "  Prog button attached: %s", YESNO(this->cover_prog_button_ != nullptr));
 }
 
@@ -47,7 +48,17 @@ void SomfyRts::program() {
   this->send_command(Command::Prog);
 }
 
-void SomfyRts::send_command(Command command) {
+void SomfyRts::open_tilt() {
+  log_component_action("OPEN_TILT", this->remote_code_);
+  this->send_command(Command::Up, this->tilt_repeat_count_);
+}
+
+void SomfyRts::close_tilt() {
+  log_component_action("CLOSE_TILT", this->remote_code_);
+  this->send_command(Command::Down, this->tilt_repeat_count_);
+}
+
+void SomfyRts::send_command(Command command, int repeat_count) {
   if (this->remote_transmitter_ == nullptr) {
     ESP_LOGE(TAG, "No remote_transmitter configured");
     return;
@@ -57,6 +68,9 @@ void SomfyRts::send_command(Command command) {
     ESP_LOGE(TAG, "Rolling code storage is not initialized");
     return;
   }
+
+  const int effective_repeat_count = repeat_count < 0 ? this->repeat_count_ : repeat_count;
+  ESP_LOGD(TAG, "Repeat count: %d", effective_repeat_count);
 
   const uint16_t rolling_code = this->storage_->next_code();
 
@@ -69,7 +83,7 @@ void SomfyRts::send_command(Command command) {
   this->build_timings(timings, frame, 2);
 
   // Repeat frames with 7 hardware sync pulses
-  for (int i = 0; i < this->repeat_count_; i++) {
+  for (int i = 0; i < effective_repeat_count; i++) {
     this->build_timings(timings, frame, 7);
   }
 

--- a/esphome/components/somfy_rts/somfy_rts.cpp
+++ b/esphome/components/somfy_rts/somfy_rts.cpp
@@ -63,9 +63,9 @@ void SomfyRts::send_command(Command command) {
 }
 
 void SomfyRts::send_command(Command command, int repeat_count) {
-  if (repeat_count < 1) {
-    ESP_LOGW(TAG, "repeat_count %d below 1, clamping to 1", repeat_count);
-    repeat_count = 1;
+  if (repeat_count < 0) {
+    ESP_LOGW(TAG, "repeat_count %d below 0, clamping to 0", repeat_count);
+    repeat_count = 0;
   } else if (repeat_count > 100) {
     ESP_LOGW(TAG, "repeat_count %d above 100, clamping to 100", repeat_count);
     repeat_count = 100;

--- a/esphome/components/somfy_rts/somfy_rts.h
+++ b/esphome/components/somfy_rts/somfy_rts.h
@@ -40,7 +40,8 @@ class SomfyRts : public Component {
   void program();
   void open_tilt();
   void close_tilt();
-  void send_command(Command command, int repeat_count = -1);
+  void send_command(Command command);
+  void send_command(Command command, int repeat_count);
 
  protected:
   remote_base::RemoteTransmitterBase *remote_transmitter_{nullptr};
@@ -53,6 +54,7 @@ class SomfyRts : public Component {
 
   RollingCodeStorage *storage_{nullptr};
 
+  void send_command_impl_(Command command, int repeat_count);
   void build_frame(uint8_t *frame, Command command, uint16_t rolling_code);
   void build_timings(remote_base::RawTimings &t, uint8_t *frame, uint8_t sync_count);
   static void send_high(remote_base::RawTimings &t, int32_t duration_usecs);
@@ -139,8 +141,11 @@ template<typename... Ts> class SendAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(int, repeat_count)
 
   void play(const Ts &... x) override {
-    const int repeat = this->repeat_count_.value_or(x..., -1);
-    this->parent_->send_command(this->command_, repeat);
+    if (this->repeat_count_.has_value()) {
+      this->parent_->send_command(this->command_, this->repeat_count_.value(x...));
+    } else {
+      this->parent_->send_command(this->command_);
+    }
   }
 
  protected:

--- a/esphome/components/somfy_rts/somfy_rts.h
+++ b/esphome/components/somfy_rts/somfy_rts.h
@@ -32,11 +32,14 @@ class SomfyRts : public Component {
   void set_storage_key(const char *storage_key) { this->storage_key_ = storage_key; }
   void set_storage_namespace(const char *storage_namespace) { this->storage_namespace_ = storage_namespace; }
   void set_repeat_count(int repeat_count) { this->repeat_count_ = repeat_count; }
+  void set_tilt_repeat_count(int tilt_repeat_count) { this->tilt_repeat_count_ = tilt_repeat_count; }
 
   void open();
   void close();
   void stop();
   void program();
+  void open_tilt();
+  void close_tilt();
 
  protected:
   remote_base::RemoteTransmitterBase *remote_transmitter_{nullptr};
@@ -45,10 +48,11 @@ class SomfyRts : public Component {
   const char *storage_key_{nullptr};
   const char *storage_namespace_{"somfy_rts"};
   int repeat_count_{4};
+  int tilt_repeat_count_{3};
 
   RollingCodeStorage *storage_{nullptr};
 
-  void send_command(Command command);
+  void send_command(Command command, int repeat_count = -1);
   void build_frame(uint8_t *frame, Command command, uint16_t rolling_code);
   void build_timings(remote_base::RawTimings &t, uint8_t *frame, uint8_t sync_count);
   static void send_high(remote_base::RawTimings &t, int32_t duration_usecs);
@@ -97,6 +101,30 @@ template<typename... Ts> class ProgramAction : public Action<Ts...> {
 
   void play(const Ts &...) override {
     this->parent_->program();
+  }
+
+ protected:
+  SomfyRts *parent_;
+};
+
+template<typename... Ts> class OpenTiltAction : public Action<Ts...> {
+ public:
+  explicit OpenTiltAction(SomfyRts *parent) : parent_(parent) {}
+
+  void play(const Ts &...) override {
+    this->parent_->open_tilt();
+  }
+
+ protected:
+  SomfyRts *parent_;
+};
+
+template<typename... Ts> class CloseTiltAction : public Action<Ts...> {
+ public:
+  explicit CloseTiltAction(SomfyRts *parent) : parent_(parent) {}
+
+  void play(const Ts &...) override {
+    this->parent_->close_tilt();
   }
 
  protected:

--- a/esphome/components/somfy_rts/somfy_rts.h
+++ b/esphome/components/somfy_rts/somfy_rts.h
@@ -40,6 +40,7 @@ class SomfyRts : public Component {
   void program();
   void open_tilt();
   void close_tilt();
+  void send_command(Command command, int repeat_count = -1);
 
  protected:
   remote_base::RemoteTransmitterBase *remote_transmitter_{nullptr};
@@ -52,7 +53,6 @@ class SomfyRts : public Component {
 
   RollingCodeStorage *storage_{nullptr};
 
-  void send_command(Command command, int repeat_count = -1);
   void build_frame(uint8_t *frame, Command command, uint16_t rolling_code);
   void build_timings(remote_base::RawTimings &t, uint8_t *frame, uint8_t sync_count);
   static void send_high(remote_base::RawTimings &t, int32_t duration_usecs);
@@ -129,6 +129,23 @@ template<typename... Ts> class CloseTiltAction : public Action<Ts...> {
 
  protected:
   SomfyRts *parent_;
+};
+
+template<typename... Ts> class SendAction : public Action<Ts...> {
+ public:
+  explicit SendAction(SomfyRts *parent) : parent_(parent) {}
+
+  void set_command(Command command) { this->command_ = command; }
+  TEMPLATABLE_VALUE(int, repeat_count)
+
+  void play(const Ts &... x) override {
+    const int repeat = this->repeat_count_.value_or(x..., -1);
+    this->parent_->send_command(this->command_, repeat);
+  }
+
+ protected:
+  SomfyRts *parent_;
+  Command command_{Command::My};
 };
 
 }  // namespace somfy_rts


### PR DESCRIPTION
## Summary
- Adds `somfy_rts.open_tilt` / `somfy_rts.close_tilt` actions for louvre
  covers, with a configurable `tilt_repeat_count` (default 3).
  Resolves #14.
- Adds a generic `somfy_rts.send` action with selectable `command`
  (`UP`/`DOWN`/`MY`/`PROG`) and templatable `repeat_count`. Covers
  long-program (pair an extra remote), micro-tilt and ad-hoc diagnostics
  without a firmware rebuild.
- Runtime repeat values are clamped to 1-100 with a warning; existing
  `open` / `close` / `stop` / `program` behavior is unchanged
  (backwards-compatible).

Commits:
- Add `open_tilt` / `close_tilt` actions for louvre covers
- Add generic `somfy_rts.send` action with templatable `repeat_count`
- Separate default and explicit `send_command` paths (clamp 1-100)

## Test plan
- [ ] `esphome config` accepts YAML with `tilt_repeat_count` set and omitted (default `3`)
- [ ] `esphome config` accepts `somfy_rts.send: { command: PROG, repeat_count: 15 }`
- [ ] `esphome config` accepts templatable `repeat_count` via `!lambda`
- [ ] `esphome compile` succeeds for the above YAMLs
- [ ] Inspect generated `main.cpp` for `set_tilt_repeat_count(...)` and `SendAction` construction
- [ ] (Hardware) Verify `open_tilt` / `close_tilt` physically tilt the louvre; sweep `tilt_repeat_count` 1..4 if `3` does not work
- [ ] (Hardware) Verify `somfy_rts.send` with `command: PROG, repeat_count: 15` triggers long-program mode

Closes #14